### PR TITLE
fix: Syntax error caused by premature end of comment block

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -239,9 +239,12 @@ function commentBlock(text?: string, padding = 0): string[] {
     return []
   }
 
+  // Avoid premature closure of the comment block due to the presence of "*/" in the text
+  const _text = text.replace(/\*\//g, '*\\/')
+
   return [
     `${indent}/**`,
-    ...text.split(/\n/g).map(l => `${indent} * ${l}`),
+    ..._text.split(/\n/g).map(l => `${indent} * ${l}`),
     `${indent} */`,
   ]
 }


### PR DESCRIPTION
### Description

fix #3 

### Additional context

Perhaps adding a test case would be better, but I'm afraid of messing up the directory structure.

