### PR TITLE
fix: union type

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -320,43 +320,46 @@ function typeFromSchema(schema: any, isSubType = false): string {
   if (!schema)
     return 'unknown'
 
+  const schemaTypes = Array.isArray(schema.type) ? schema.type : [schema.type]
   const types: string[] = []
 
-  switch (schema.type) {
-    case 'boolean':
-      types.push('boolean')
-      break
-    case 'string':
-      if (schema.enum) {
-        types.push(...schema.enum.map((v: string) => JSON.stringify(v)))
+  for (const schemaType of schemaTypes) {
+    switch (schemaType) {
+      case 'boolean':
+        types.push('boolean')
         break
-      }
-      types.push('string')
-      break
-    case 'number':
-      types.push('number')
-      break
-    case 'array':
-      if (schema.items) {
-        types.push(`${typeFromSchema(schema.items, true)}[]`)
+      case 'string':
+        if (schema.enum) {
+          types.push(...schema.enum.map((v: string) => JSON.stringify(v)))
+          break
+        }
+        types.push('string')
         break
-      }
-      types.push('unknown[]')
-      break
-    case 'object':
-      if (schema.properties) {
-        const propertyKeyValues = Object.entries(schema.properties).map(([key, value]) => {
-          return `'${key}': ${typeFromSchema(value, true)}`
-        })
+      case 'number':
+        types.push('number')
+        break
+      case 'array':
+        if (schema.items) {
+          types.push(`${typeFromSchema(schema.items, true)}[]`)
+          break
+        }
+        types.push('unknown[]')
+        break
+      case 'object':
+        if (schema.properties) {
+          const propertyKeyValues = Object.entries(schema.properties).map(([key, value]) => {
+            return `'${key}': ${typeFromSchema(value, true)}`
+          })
 
-        types.push(`{ ${propertyKeyValues.join('; ')} }`)
+          types.push(`{ ${propertyKeyValues.join('; ')} }`)
 
+          break
+        }
+        types.push('Record<string, unknown>')
         break
-      }
-      types.push('Record<string, unknown>')
-      break
-    default:
-      types.push('unknown')
+      default:
+        types.push('unknown')
+    }
   }
 
   if (!isSubType && schema.type !== 'object') {

--- a/test/output/i18n-ally.ts
+++ b/test/output/i18n-ally.ts
@@ -381,7 +381,7 @@ export type ConfigKey =
 export interface ConfigKeyTypeMap {
   "i18n-ally.disabled": boolean,
   "i18n-ally.autoDetection": boolean,
-  "i18n-ally.localesPaths": (unknown | undefined),
+  "i18n-ally.localesPaths": (string | string[] | undefined),
   "i18n-ally.encoding": string,
   "i18n-ally.sourceLanguage": (string | undefined),
   "i18n-ally.displayLanguage": (string | undefined),
@@ -1611,7 +1611,7 @@ export const configs = {
 export interface ScopedConfigKeyTypeMap {
   "disabled": boolean,
   "autoDetection": boolean,
-  "localesPaths": (unknown | undefined),
+  "localesPaths": (string | string[] | undefined),
   "encoding": string,
   "sourceLanguage": (string | undefined),
   "displayLanguage": (string | undefined),


### PR DESCRIPTION
### Description

```jsonc
{
  "type": "boolean",
  "default": false
},
{
  "type": ["boolean", "string"], // union type
  "default": false
}
```

The config schema type can be an array that should be generated as a union type

```ts
boolean | string
```