### PR TITLE
feat: support markdownDescription on package.json

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -77,7 +77,7 @@ export function generateMarkdown(packageJson: any) {
           const defaultVal = defaultValFromSchema(value) || ''
           return [
             `\`${key}\``,
-            value?.description || '',
+            value?.description || values?.markdownDescription || '',
             `\`${String(value.type)}\``,
             defaultVal.length < MAX_TABLE_COL_CHAR ? `\`${defaultVal}\`` : 'See package.json',
           ]


### PR DESCRIPTION
### Description

- Support `markdownDescription` field, e.g:

```json
"find-it-faster.pickFileFromGitStatus.previewCommand": {
					"markdownDescription": "When populated: Used by `fzf` to produce the preview when picking a file from git status. Use `{}` to indicate the filename. Example: `git diff --color=always -- {}`.",
					"type": "string",
					"default": ""
				},
```

### Linked Issues


### Additional context
