### PR TITLE
fix: handle undefined nestedConfig in generateDTS function

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -293,7 +293,7 @@ export function generateDTS(packageJson: any, options: GenerateOptions = {}) {
   lines.push(`}`, '')
 
   lines.push(`export interface NestedScopedConfigs {`)
-  for (const entry of Object.entries(nestedConfig[extensionScope])) {
+  for (const entry of Object.entries(nestedConfig[extensionScope] ?? {})) {
     generateNestedConfig(entry, 1, true)
   }
   lines.push(`}`, '')


### PR DESCRIPTION
If the package.json file does not have the `contributes` field, it will result in an `undefined` error.