### PR TITLE
fix: escape certain characters for Markdown - replaceAll

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -46,10 +46,10 @@ export function generateMarkdown(packageJson: any) {
 
   function markdownEscape(text: string) {
     return text
-      .replace('&', '&amp;')
-      .replace('<', '&lt;')
-      .replace('>', '&gt;')
-      .replace('|', '&vert;')
+      .replaceAll('&', '&amp;')
+      .replaceAll('<', '&lt;')
+      .replaceAll('>', '&gt;')
+      .replaceAll('|', '&vert;')
   }
 
   let commandsTable = [


### PR DESCRIPTION
### Description

In Markdown Escape the `string.replace()` replaces only the first occurrence. Now it uses `string.replaceAll()`
