### PR TITLE
feat: add support for languages, custom editors, and chat participants

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -26,9 +26,13 @@ cli.command('[input]', 'Generate TypeScript files from package.json')
 
     if (options.readme && options.readme !== 'false') {
       const raw = await fs.readFile(options.readme, 'utf-8')
+
       const content = raw
         .replace(/<!-- commands -->[\s\S]*<!-- commands -->/, `<!-- commands -->\n\n${markdown.commandsTable}\n\n<!-- commands -->`)
         .replace(/<!-- configs -->[\s\S]*<!-- configs -->/, `<!-- configs -->\n\n${markdown.configsTable}\n\n<!-- configs -->`)
+        .replace(/<!-- languages -->[\s\S]*<!-- languages -->/, `<!-- languages -->\n\n${markdown.languagesTable}\n\n<!-- languages -->`)
+        .replace(/<!-- customEditors -->[\s\S]*<!-- customEditors -->/, `<!-- customEditors -->\n\n${markdown.customEditorsTable}\n\n<!-- customEditors -->`)
+        .replace(/<!-- chatParticipants -->[\s\S]*<!-- chatParticipants -->/, `<!-- chatParticipants -->\n\n${markdown.chatParticipantsTable}\n\n<!-- chatParticipants -->`)
 
       if (raw === content && !raw.includes('<!-- commands -->') && !raw.includes('<!-- configs -->')) {
         console.log('Add `<!-- commands --><!-- commands -->` and `<!-- configs --><!-- configs -->` to your README.md to insert commands and configurations table')


### PR DESCRIPTION
Description
This PR extends the VS Code extension generator to support three additional contribution points that are commonly used in modern VS Code extensions:
🌍 Languages Support
setting:
```
 "snippets": [
      {
        "language": "matrix",
        "path": "xxx"
      }
    ],
"languages": [
      {
        "id": "matrix",
        "extensions": [
          ".matrix"
        ],
        "aliases": [
          "matrix",
          "RelaxNG Compact"
        ],
        "icon": {
          "light": "/resources/icons/matrix-icon.svg",
          "dark": "/resources/icons/matrix-icon.svg"
        },
        "configuration": "/resources/matrix.language-configuration.json"
      }
    ],
"grammars": [
      {
        "language": "matrix",
        "scopeName": "text.json",
        "path": "/resources/syntaxes/xml.tmLanguage.json"
      }
    ],
```
before
```
 languages.setLanguageConfiguration('matrix', getIndentationRulesForJson());
```
after
```
languages.setLanguageConfiguration(
      meta.languages.matrix,
      getIndentationRulesForJson()
    );
```
✏️ Custom Editors Support
setting:
```
"customEditors": [
      {
        "viewType": "id.vscode-matrix-text",
        "displayName": "Matrix",
        "selector": [
          {
            "filenamePattern": "*.matrix"
          }
        ],
        "priority": "default"
      }
    ],
```
before:
```
window.registerCustomEditorProvider(
      'id.vscode-matrix-text',
      new MatrixEditorCustomProvider(contextUtils.context!),
      {
        webviewOptions: {
          retainContextWhenHidden: true,
        },
      }
    )
```
after
```
window.registerCustomEditorProvider(
      meta.customEditors.idVscodeMatrixText,
      new MatrixEditorCustomProvider(contextUtils.context!),
      {
        webviewOptions: {
          retainContextWhenHidden: true,
        },
      }
    )
```


💬 Chat Participants Support
setting 
```
"chatParticipants": [
      {
        "id": "id-matrix.matrix",
        "name": "Matrix",
        "description": "Hi 👋 ! What can I do for you?",
        "isSticky": true,
        "disambiguation": [
          {
            "category": "matrix",
            "description": "matrix api definition and implementation",
            "examples": [
              "Matrix api's implementation ",
              "Which xml or Json in matrix folder is the definition of Matrix api",
              "The information of the matrix api. In which fields and which version",
              "Is there an updated version of a certain matrix api"
            ]
          },
          {
            "category": "matrix",
            "description": "The implementation process or flow of the matrix api is displayed through process orchestration",
            "examples": [
              "How many nodes are there in the matrix api implementation",
              "Is there a possibility of an infinite loop in the matrix api workflow",
            ]
          }
        ]
      }
    ]
```
before
```
 chat.createChatParticipant(
    'id-matrix.matrix',
    handleMatrixParticipant
  );
```
after
```
chat.createChatParticipant(
    meta.chatParticipants.idMatrixMatrix,
    handleMatrixParticipant
  );
```