### PR TITLE
feat: add list format & marker suffix variants

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -16,7 +16,8 @@ cli.command('[input]', 'Generate TypeScript files from package.json')
     const json = JSON.parse(await fs.readFile(input, 'utf-8'))
     if (!json.publisher)
       throw new Error('This package.json does not seem to be a valid VSCode extension package.json')
-    const { dts, markdown } = await generate(json, {
+
+    const { dts, markdown } = generate(json, {
       namespace: options.namespace === 'false' ? false : options.namespace,
       extensionScope: options.scope,
     })
@@ -28,14 +29,22 @@ cli.command('[input]', 'Generate TypeScript files from package.json')
       const raw = await fs.readFile(options.readme, 'utf-8')
 
       const content = raw
-        .replace(/<!-- commands -->[\s\S]*<!-- commands -->/, `<!-- commands -->\n\n${markdown.commandsTable}\n\n<!-- commands -->`)
-        .replace(/<!-- configs -->[\s\S]*<!-- configs -->/, `<!-- configs -->\n\n${markdown.configsTable}\n\n<!-- configs -->`)
-        .replace(/<!-- languages -->[\s\S]*<!-- languages -->/, `<!-- languages -->\n\n${markdown.languagesTable}\n\n<!-- languages -->`)
-        .replace(/<!-- customEditors -->[\s\S]*<!-- customEditors -->/, `<!-- customEditors -->\n\n${markdown.customEditorsTable}\n\n<!-- customEditors -->`)
-        .replace(/<!-- chatParticipants -->[\s\S]*<!-- chatParticipants -->/, `<!-- chatParticipants -->\n\n${markdown.chatParticipantsTable}\n\n<!-- chatParticipants -->`)
+        .replace(/<!-- (commands|commands-table) -->[\s\S]*?<!-- (commands|commands-table) -->/, `<!-- $1 -->\n\n${markdown.commandsTable}\n\n<!-- $2 -->`)
+        .replace(/<!-- (configs|configs-table) -->[\s\S]*?<!-- (configs|configs-table) -->/, `<!-- $1 -->\n\n${markdown.configsTable}\n\n<!-- $2 -->`)
+        .replace(/<!-- (languages|languages-table) -->[\s\S]*?<!-- (languages|languages-table) -->/, `<!-- $1 -->\n\n${markdown.languagesTable}\n\n<!-- $2 -->`)
+        .replace(/<!-- (customEditors|customEditors-table) -->[\s\S]*?<!-- (customEditors|customEditors-table) -->/, `<!-- $1 -->\n\n${markdown.customEditorsTable}\n\n<!-- $2 -->`)
+        .replace(/<!-- (chatParticipants|chatParticipants-table) -->[\s\S]*?<!-- (chatParticipants|chatParticipants-table) -->/, `<!-- $1 -->\n\n${markdown.chatParticipantsTable}\n\n<!-- $2 -->`)
 
-      if (raw === content && !raw.includes('<!-- commands -->') && !raw.includes('<!-- configs -->')) {
+        // lists
+        .replace(/<!-- (commands-list) -->[\s\S]*?<!-- (commands-list) -->/, `<!-- $1 -->\n\n${markdown.commandsList}\n\n<!-- $2 -->`)
+        .replace(/<!-- (configs-list) -->[\s\S]*?<!-- (configs-list) -->/, `<!-- $1 -->\n\n${markdown.configsList}\n\n<!-- $2 -->`)
+        .replace(/<!-- (languages-list) -->[\s\S]*?<!-- (languages-list) -->/, `<!-- $1 -->\n\n${markdown.languagesList}\n\n<!-- $2 -->`)
+        .replace(/<!-- (customEditors-list) -->[\s\S]*?<!-- (customEditors-list) -->/, `<!-- $1 -->\n\n${markdown.customEditorsList}\n\n<!-- $2 -->`)
+        .replace(/<!-- (chatParticipants-list) -->[\s\S]*?<!-- (chatParticipants-list) -->/, `<!-- $1 -->\n\n${markdown.chatParticipantsList}\n\n<!-- $2 -->`)
+
+      if (raw === content && !raw.includes('<!-- commands') && !raw.includes('<!-- configs')) {
         console.log('Add `<!-- commands --><!-- commands -->` and `<!-- configs --><!-- configs -->` to your README.md to insert commands and configurations table')
+        console.log('Or use `<!-- commands-table -->` for table format, `<!-- commands-list -->` for list format')
       }
       else {
         await fs.writeFile(options.readme, content, 'utf-8')

--- a/src/markdown.ts
+++ b/src/markdown.ts
@@ -1,5 +1,5 @@
 import { defaultValFromSchema, getConfigObject } from './schema'
-import { formatTable, markdownEscape } from './utils'
+import { formatList, formatTable, markdownEscape } from './utils'
 
 export function generateMarkdown(packageJson: any) {
   const MAX_TABLE_COL_CHAR = 150
@@ -121,5 +121,10 @@ export function generateMarkdown(packageJson: any) {
     languagesTable: formatTable(languagesTable),
     customEditorsTable: formatTable(customEditorsTable),
     chatParticipantsTable: formatTable(chatParticipantsTable),
+    commandsList: formatList(commandsTable),
+    configsList: formatList(configsTable),
+    languagesList: formatList(languagesTable),
+    customEditorsList: formatList(customEditorsTable),
+    chatParticipantsList: formatList(chatParticipantsTable),
   }
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -55,3 +55,38 @@ export function markdownEscape(text: string) {
     .replaceAll('>', '&gt;')
     .replaceAll('|', '&vert;')
 }
+
+export function formatList(data: string[][]) {
+  if (!data.length || data.length === 1)
+    return '**No data**'
+
+  const [header, ...rows] = data
+
+  // The command list should be treated specially
+  // as we want the title to be the heading, not the command id
+  const isCommandTable = header.length === 2
+    && header[0].trim().toLowerCase() === 'command'
+    && header[1].trim().toLowerCase() === 'title'
+
+  const headingIndex = isCommandTable ? 1 : 0
+  const fieldOrder = isCommandTable ? [1, 0] : header.map((_, i) => i)
+
+  return rows.map((row) => {
+    const heading = row[headingIndex].trim() || '(Unnamed)'
+
+    const lines = [`#### ${heading}`]
+
+    for (const idx of fieldOrder) {
+      if (idx === headingIndex)
+        continue
+
+      const val = (row[idx] || '').trim()
+      if (!val || val === '-')
+        continue
+
+      lines.push(`${header[idx]}: ${val}  `)
+    }
+
+    return lines.join('\n')
+  }).join('\n\n')
+}


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

This PR adds a new list output style for generated documentation alongside the existing table format. It also introduces optional `-list` and `-table` marker suffixes while keeping the original unsuffixed markers fully functional. A small regex bug that allowed different marker types to clash has been fixed so only matching styles are paired.

These changes improve readability in narrow or plain-text contexts, make the format system easier to extend later, and make parsing safer. Existing projects see no behavior change unless they opt in to the new suffixes.

### Linked Issues

resolves #15

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
